### PR TITLE
Add skeleton upgrades menu

### DIFF
--- a/Meat Spin/Meat Spin WatchKit App/Base.lproj/Interface.storyboard
+++ b/Meat Spin/Meat Spin WatchKit App/Base.lproj/Interface.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="13771" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="AgC-eL-Hgc">
-    <device id="watch38" orientation="portrait">
+    <device id="watch42" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -29,6 +29,11 @@
                                 </swipeGestureRecognizer>
                             </gestureRecognizers>
                         </imageView>
+                        <button width="1" alignment="left" title="U P G R A D E S" id="dIq-Po-asV">
+                            <connections>
+                                <segue destination="NTo-xX-w6t" kind="modal" id="se8-D4-agX"/>
+                            </connections>
+                        </button>
                     </items>
                     <connections>
                         <outlet property="chickenImg" destination="gSz-2h-YoM" id="5SB-ip-9Xc"/>
@@ -38,12 +43,48 @@
             </objects>
             <point key="canvasLocation" x="220" y="345"/>
         </scene>
-        <!--Interface Controller-->
-        <scene sceneID="dAM-vg-kJu">
+        <!--Upgrades Interface Controller-->
+        <scene sceneID="dJe-Jn-VvG">
             <objects>
-                <controller id="p2d-V7-MsM"/>
+                <controller id="NTo-xX-w6t" customClass="UpgradesInterfaceController" customModule="Meat_Spin_WatchKit_Extension">
+                    <items>
+                        <table alignment="left" id="Qes-2k-KsX">
+                            <items>
+                                <tableRow identifier="UpgradesRowController" id="IIY-fH-8xW" customClass="UpgradesRowController" customModule="Meat_Spin_WatchKit_Extension">
+                                    <group key="rootItem" width="1" height="0.0" alignment="left" layout="vertical" id="8Oy-KJ-EXw">
+                                        <items>
+                                            <group width="1" alignment="left" id="Yda-hZ-E0V">
+                                                <items>
+                                                    <label width="1" height="21" alignment="left" verticalAlignment="center" text="Name" id="lpm-Tm-522">
+                                                        <fontDescription key="font" style="UICTFontTextStyleBody"/>
+                                                    </label>
+                                                </items>
+                                            </group>
+                                            <separator alignment="left" id="LN5-Xt-alk"/>
+                                            <group width="1" alignment="left" id="6Qg-zG-fx5">
+                                                <items>
+                                                    <label alignment="left" verticalAlignment="center" text="COST:" id="uV0-9e-VNH"/>
+                                                    <label alignment="left" verticalAlignment="center" text="Cost" id="j3A-g5-4dB"/>
+                                                    <imageView width="41" alignment="right" verticalAlignment="center" id="V5K-5b-en5"/>
+                                                </items>
+                                            </group>
+                                        </items>
+                                    </group>
+                                    <connections>
+                                        <outlet property="UpgradeBuyImage" destination="V5K-5b-en5" id="wnS-f2-g1y"/>
+                                        <outlet property="UpgradeCostLabel" destination="j3A-g5-4dB" id="HVC-XU-Smk"/>
+                                        <outlet property="UpgradeNameLabel" destination="lpm-Tm-522" id="d8G-4c-mnK"/>
+                                    </connections>
+                                </tableRow>
+                            </items>
+                        </table>
+                    </items>
+                    <connections>
+                        <outlet property="TableElement" destination="Qes-2k-KsX" id="iL8-ip-oyv"/>
+                    </connections>
+                </controller>
             </objects>
-            <point key="canvasLocation" x="453" y="345"/>
+            <point key="canvasLocation" x="467.28205128205133" y="336.94871794871796"/>
         </scene>
         <!--Static Notification Interface Controller-->
         <scene sceneID="AEw-b0-oYE">

--- a/Meat Spin/Meat Spin WatchKit Extension/UpgradesInterfaceController.swift
+++ b/Meat Spin/Meat Spin WatchKit Extension/UpgradesInterfaceController.swift
@@ -1,0 +1,32 @@
+//
+//  UpgradesInterfaceController.swift
+//  Meat Spin WatchKit Extension
+//
+//  Created by Wade Mauger on 3/9/18.
+//  Copyright © 2018 SWEN-356. All rights reserved.
+//
+
+import WatchKit
+import Foundation
+
+class UpgradesInterfaceController: WKInterfaceController {
+    @IBOutlet var TableElement: WKInterfaceTable!
+    let seasonings = ["Lemon Pepper": 0, "Cajon Rub": 1, "Barbeque": 2]
+    
+    override init() {
+        super.init()
+        loadTableData()
+    }
+    
+    private func loadTableData() {
+        TableElement.setNumberOfRows(3, withRowType: "UpgradesRowController")
+        
+        for (name, price) in seasonings {
+            let row = TableElement.rowController(at: price) as! UpgradesRowController
+            row.UpgradeNameLabel.setText(name)
+            row.UpgradeCostLabel.setText(String(price))
+        }
+    
+    }
+    
+}

--- a/Meat Spin/Meat Spin WatchKit Extension/UpgradesRowController.swift
+++ b/Meat Spin/Meat Spin WatchKit Extension/UpgradesRowController.swift
@@ -1,0 +1,16 @@
+//
+//  UpgradesRowController.swift
+//  Meat Spin WatchKit Extension
+//
+//  Created by Wade Mauger on 3/9/18.
+//  Copyright © 2018 SWEN-356. All rights reserved.
+//
+
+import Foundation
+import WatchKit
+
+class UpgradesRowController: NSObject {
+    @IBOutlet var UpgradeCostLabel: WKInterfaceLabel!
+    @IBOutlet var UpgradeNameLabel: WKInterfaceLabel!
+    @IBOutlet var UpgradeBuyImage: WKInterfaceImage!
+}

--- a/Meat Spin/Meat Spin.xcodeproj/project.pbxproj
+++ b/Meat Spin/Meat Spin.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		1E61F063202E069100A81C7A /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E61F062202E069100A81C7A /* NotificationController.swift */; };
 		1E61F065202E069100A81C7A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1E61F064202E069100A81C7A /* Assets.xcassets */; };
 		3134E66520376A32001FF3C9 /* ChickenImageStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3134E66420376A32001FF3C9 /* ChickenImageStateMachine.swift */; };
+		31EA3E172052F38100D6794E /* UpgradesInterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EA3E162052F38100D6794E /* UpgradesInterfaceController.swift */; };
+		31EA3E192053189900D6794E /* UpgradesRowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31EA3E182053189900D6794E /* UpgradesRowController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -107,6 +109,8 @@
 		1E61F066202E069100A81C7A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1E61F067202E069100A81C7A /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
 		3134E66420376A32001FF3C9 /* ChickenImageStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChickenImageStateMachine.swift; sourceTree = "<group>"; };
+		31EA3E162052F38100D6794E /* UpgradesInterfaceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesInterfaceController.swift; sourceTree = "<group>"; };
+		31EA3E182053189900D6794E /* UpgradesRowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesRowController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -216,6 +220,8 @@
 				1E61F066202E069100A81C7A /* Info.plist */,
 				1E61F067202E069100A81C7A /* PushNotificationPayload.apns */,
 				3134E66420376A32001FF3C9 /* ChickenImageStateMachine.swift */,
+				31EA3E162052F38100D6794E /* UpgradesInterfaceController.swift */,
+				31EA3E182053189900D6794E /* UpgradesRowController.swift */,
 			);
 			path = "Meat Spin WatchKit Extension";
 			sourceTree = "<group>";
@@ -444,6 +450,8 @@
 			files = (
 				1E61F063202E069100A81C7A /* NotificationController.swift in Sources */,
 				1E61F061202E069100A81C7A /* ExtensionDelegate.swift in Sources */,
+				31EA3E172052F38100D6794E /* UpgradesInterfaceController.swift in Sources */,
+				31EA3E192053189900D6794E /* UpgradesRowController.swift in Sources */,
 				1E61F05F202E069100A81C7A /* InterfaceController.swift in Sources */,
 				3134E66520376A32001FF3C9 /* ChickenImageStateMachine.swift in Sources */,
 			);


### PR DESCRIPTION
Hey, guys

Just got something working and wanted to verify that it's what we wanted:

![upgrades-menu](https://user-images.githubusercontent.com/7254185/37234326-199130f2-23c5-11e8-9cfb-55e77d7ba661.gif)

Things that still need done before merge:

- [ ] Get functioning onClick handling
- [ ] Render something to indicate the upgrade state (purchased / can purchase / cannot afford). I have a small image element with nothing in it to the right of the cost, I figured we would just show a greyed plus sign, a green plus sign, or a green checkmark to indicate those states, but if you guys have suggestions lemme hear them
- [ ] probably more?